### PR TITLE
Updating resource to work with onesync infinity but to still have backwards compatibility

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -79,3 +79,33 @@ AddEventHandler('InteractSound_CL:PlayWithinDistance', function(playerNetId, max
         })
     end
 end)
+
+
+------
+-- RegisterNetEvent LIFE_CL:Sound:PlayWithinDistanceOS (Bigmode varient of InteractSound_CL:PlayWithinDistance)
+--
+-- @param playerCoords    - The coords of the player making the sound
+--
+-- @param maxDistance     - The maximum float distance (client uses Vdist) to allow the player to
+--                        - hear the soundFile being played.
+-- @param soundFile       - The name of the soundfile within the client/html/sounds/ folder.
+--                        - Can also specify a folder/sound file.
+-- @param soundVolume     - The volume at which the soundFile should be played. Nil or don't
+--                        - provide it for the default of standardVolumeOutput. Should be between
+--                        - 0.1 to 1.0.
+--
+-- Starts playing a sound on a client if the client is within the specificed maxDistance from the playOnEntity.
+-- @TODO Change sound volume based on the distance the player is away from the playOnEntity.
+------
+RegisterNetEvent('InteractSound_CL:PlayWithinDistanceOS')
+AddEventHandler('InteractSound_CL:PlayWithinDistanceOS', function(playerCoords, maxDistance, soundFile, soundVolume)
+    local lCoords = GetEntityCoords(GetPlayerPed(-1))
+    local distIs  = Vdist(lCoords.x, lCoords.y, lCoords.z, playerCoords.x, playerCoords.y, playerCoords.z)
+    if(distIs <= maxDistance) then
+        SendNUIMessage({
+            transactionType     = 'playSound',
+            transactionFile     = soundFile,
+            transactionVolume   = soundVolume
+        })
+    end
+end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,5 +1,6 @@
--- Manifest Version
-resource_manifest_version '77731fab-63ca-442c-a67b-abc70f28dfa5'
+-- FXVersion Version
+fx_version 'adamant'
+games { 'gta5' }
 
 -- Client Scripts
 client_script 'client/main.lua'
@@ -8,7 +9,7 @@ client_script 'client/main.lua'
 server_script 'server/main.lua'
 
 -- NUI Default Page
-ui_page('client/html/index.html')
+ui_page "client/html/index.html"
 
 -- Files needed for NUI
 -- DON'T FORGET TO ADD THE SOUND FILES TO THIS!

--- a/server/main.lua
+++ b/server/main.lua
@@ -83,5 +83,9 @@ end)
 ------
 RegisterServerEvent('InteractSound_SV:PlayWithinDistance')
 AddEventHandler('InteractSound_SV:PlayWithinDistance', function(maxDistance, soundFile, soundVolume)
+  if GetConvar("onesync_enableInfinity", "false") == "true" then
+    TriggerClientEvent('InteractSound_CL:PlayWithinDistanceOS', -1, GetEntityCoords(GetPlayerPed(source)), maxDistance, soundFile, soundVolume)
+  else
     TriggerClientEvent('InteractSound_CL:PlayWithinDistance', -1, source, maxDistance, soundFile, soundVolume)
+  end
 end)


### PR DESCRIPTION
- Updated __resource.lua to fxmanifest.lua.
- Added `InteractSound_CL:PlayWithinDistanceOS` which takes coords sent to it from the server as it's first parameter (needed for it to work with onesync infinity.
- Added if statement to `InteractSound_SV:PlayWithinDistance` which allows for backwards compatibility for servers that are not yet using onesync inifinty.